### PR TITLE
CI: fix store path

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -65,6 +65,7 @@ runs:
 
   - name: Save cached ac-library-hs
     uses: actions/cache/save@v4
+    if: steps.lib-cache.outputs.cache-hit != 'true'
     env:
       key: ${{ runner.os }}-ghc-${{ matrix.ghc-version }}-cabal-${{ steps.vars.outputs.cabal-version }}
     with:

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,10 +12,10 @@ runs:
       ver="$(/usr/local/.ghcup/bin/cabal --version | head -n 1 | awk '{print $3}')"
       echo "cabal-version=$ver" >> "$GITHUB_OUTPUT"
       echo "cabal-version=$ver"
-      echo "store-path=~/.local/state/cabal/store" >> "$GITHUB_OUTPUT"
-      echo "store-path=~/.local/state/cabal/store"
-      # echo "store-path=~/.cabal/store" >> "$GITHUB_OUTPUT"
-      # echo "store-path=~/.cabal/store"
+      # echo "store-path=~/.local/state/cabal/store" >> "$GITHUB_OUTPUT"
+      # echo "store-path=~/.local/state/cabal/store"
+      echo "store-path=~/.cabal/store" >> "$GITHUB_OUTPUT"
+      echo "store-path=~/.cabal/store"
 
   - name: Configure the build
     shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,10 +12,10 @@ runs:
       ver="$(/usr/local/.ghcup/bin/cabal --version | head -n 1 | awk '{print $3}')"
       echo "cabal-version=$ver" >> "$GITHUB_OUTPUT"
       echo "cabal-version=$ver"
-      # echo "store-path=~/.local/state/cabal/store" >> "$GITHUB_OUTPUT"
-      # echo "store-path=~/.local/state/cabal/store"
-      echo "store-path=~/.cabal/store" >> "$GITHUB_OUTPUT"
-      echo "store-path=~/.cabal/store"
+      echo "store-path=~/.local/state/cabal/store" >> "$GITHUB_OUTPUT"
+      echo "store-path=~/.local/state/cabal/store"
+      # echo "store-path=~/.cabal/store" >> "$GITHUB_OUTPUT"
+      # echo "store-path=~/.cabal/store"
 
   - name: Configure the build
     shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -14,8 +14,6 @@ runs:
       echo "cabal-version=$ver"
       echo "store-path=~/.local/state/cabal/store" >> "$GITHUB_OUTPUT"
       echo "store-path=~/.local/state/cabal/store"
-      # echo "store-path=~/.cabal/store" >> "$GITHUB_OUTPUT"
-      # echo "store-path=~/.cabal/store"
 
   - name: Configure the build
     shell: bash

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -15,13 +15,14 @@ runs:
     shell: bash
     run: |
       ls -lA ~/ | grep .ghcup # we have ~/.ghcup -> /usr/local/.ghcup
-      cat ~/.cabal/config || true
-      cat ~/.config/cabal/config || true
 
       /usr/local/.ghcup/bin/cabal --version
-
-      # This crates `~/.config/cabal/config`. It's super important for having persistent cabal stoer path.
       /usr/local/.ghcup/bin/cabal path
+
+      # Does it already have store path?
+      echo >> !!!!!!!!!!!!!
+      cat ~/.config/cabal/config
+      echo >> !!!!!!!!!!!!!
 
       # Cabal used to be using non-xdg path
       # https://github.com/haskell/cabal/blob/master/release-notes/cabal-install-3.10.1.0.md#significant-changes
@@ -96,12 +97,12 @@ runs:
     shell: bash
     run: |
       mv /usr/local/.ghcup/bin/cabal{-old,}
+
       cabal path # the store path must be ~/.local/state/cabal/store
-      cat ~/.cabal/config ||
-      rm ~/.cabal/config ||
-      cabal path # the store path must be ~/.local/state/cabal/store
-      cat ~/.config/cabal/config ||
-      rm ~/.config/cabal/config ||
+      echo >> !!!!!!!!!!!!!
+      cat ~/.config/cabal/config
+      echo >> !!!!!!!!!!!!!
+      rm ~/.config/cabal/config
       cabal path # the store path must be ~/.local/state/cabal/store
 
   - name: Inspect

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -17,18 +17,31 @@ runs:
       /usr/local/.ghcup/bin/cabal --version
       /usr/local/.ghcup/bin/cabal path
 
+      # Cabal path change:
+      # https://github.com/haskell/cabal/blob/master/release-notes/cabal-install-3.10.1.0.md#significant-changes
+      echo "Default XDG paths:"
+      echo "XDG_STATE_HOME: $XDG_STATE_HOME"
+      echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
+      echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
+
+      echo "Setting some XDG paths for cabal.."
+      echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_OUTPUT"
+      echo "XDG_STATE_HOME=$HOME/.local/state" >> "$GITHUB_OUTPUT"
+      echo "XDG_CACHE_HOME=$HOME/.cache" >> "$GITHUB_OUTPUT"
+
   # Because we cannot have `env` vars in composite action:
   - name: Define env-like vars
     id: vars
     shell: bash
     run: |
+      /usr/local/.ghcup/bin/cabal path
       ver="$(/usr/local/.ghcup/bin/cabal --version | head -n 1 | awk '{print $3}')"
       echo "cabal-version=$ver" >> "$GITHUB_OUTPUT"
       echo "cabal-version=$ver"
       # The dummy version MUST NOT be equal to the preinstalled version, otherwise Cabal is overridden (?) and
       # we cannot share the cache:
-      echo "dummy-cabal-version=3.10" >> "$GITHUB_OUTPUT"
-      echo "dummy-cabal-version=3.10"
+      echo "dummy-cabal-version=3.12" >> "$GITHUB_OUTPUT"
+      echo "dummy-cabal-version=3.12"
 
   # FIXME: The cache is too large. Select necessary files in `lib/`.
   - name: Restore GHC ${{ inputs.ghc-version }}
@@ -45,13 +58,15 @@ runs:
     if: steps.ghc-cache.outputs.cache-hit == 'true'
     shell: bash
     run: |
+      # remove the configuration file in order to match to the initial state, namely the store path:
+      /home/runner/.config/cabal/config
       # setup PATH manually (since `haskell-actions/setup` is not run on cache hit)
       echo "$HOME/.ghcup/ghc/${{ inputs.ghc-version }}/bin" >> "$GITHUB_PATH"
       echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
       # inspect preinstalled versions of GHC and Cabal
       ghc --version
       cabal --version
-      cabal path
+      cabal path # the store path must be ~/.local/state/cabal/store
 
   # I don't want to install Cabal with haskell-actions@setup, so:
   - name: Pre downloading GHC ${{ inputs.ghc-version }}

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -14,6 +14,10 @@ runs:
   - name: Inspect
     shell: bash
     run: |
+      ls -lA ~/ | grep .ghcup # we have ~/.ghcup -> /usr/local/.ghcup
+      cat ~/.cabal/config || true
+      cat ~/.config/cabal/config || true
+
       /usr/local/.ghcup/bin/cabal --version
 
       # This crates `~/.config/cabal/config`. It's super important for having persistent cabal stoer path.
@@ -92,6 +96,13 @@ runs:
     shell: bash
     run: |
       mv /usr/local/.ghcup/bin/cabal{-old,}
+      cabal path # the store path must be ~/.local/state/cabal/store
+      cat ~/.cabal/config ||
+      rm ~/.cabal/config ||
+      cabal path # the store path must be ~/.local/state/cabal/store
+      cat ~/.config/cabal/config ||
+      rm ~/.config/cabal/config ||
+      cabal path # the store path must be ~/.local/state/cabal/store
 
   - name: Inspect
     shell: bash

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -26,11 +26,21 @@ runs:
       echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
       echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
 
+      echo "Setting some XDG paths for cabal.."
+      echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_OUTPUT"
+      echo "XDG_STATE_HOME=$HOME/.local/state" >> "$GITHUB_OUTPUT"
+      echo "XDG_CACHE_HOME=$HOME/.cache" >> "$GITHUB_OUTPUT"
+
   # Because we cannot have `env` vars in composite action:
   - name: Define env-like vars
     id: vars
     shell: bash
     run: |
+      echo "Current XDG paths:"
+      echo "XDG_STATE_HOME: $XDG_STATE_HOME"
+      echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
+      echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
+
       /usr/local/.ghcup/bin/cabal path
       ver="$(/usr/local/.ghcup/bin/cabal --version | head -n 1 | awk '{print $3}')"
       echo "cabal-version=$ver" >> "$GITHUB_OUTPUT"
@@ -83,10 +93,6 @@ runs:
     run: |
       mv /usr/local/.ghcup/bin/cabal{-old,}
 
-      # come back to the initial state, otherwise the path is wrong
-      rm ~/.cabal/config || true
-      rm ~/.config/cabal/config || true
-
   - name: Inspect
     shell: bash
     run: |
@@ -95,7 +101,7 @@ runs:
       ghc --version
       which cabal
       cabal --version
-      cabal path
+      cabal path # make sure the cabal store points to `~/.local/state/cabal/store`
 
   - name: Save GHC cache
     uses: actions/cache/save@v4

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -11,6 +11,12 @@ runs:
   using: composite
   steps:
 
+  - name: Inspect
+    shell: bash
+    run: |
+      /usr/local/.ghcup/bin/cabal --version
+      /usr/local/.ghcup/bin/cabal path
+
   # Because we cannot have `env` vars in composite action:
   - name: Define env-like vars
     id: vars

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -27,9 +27,9 @@ runs:
       echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
 
       echo "Setting some XDG paths for cabal.."
-      echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_OUTPUT"
-      echo "XDG_STATE_HOME=$HOME/.local/state" >> "$GITHUB_OUTPUT"
-      echo "XDG_CACHE_HOME=$HOME/.cache" >> "$GITHUB_OUTPUT"
+      echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_ENV"
+      echo "XDG_STATE_HOME=$HOME/.local/state" >> "$GITHUB_ENV"
+      echo "XDG_CACHE_HOME=$HOME/.cache" >> "$GITHUB_ENV"
 
   # Because we cannot have `env` vars in composite action:
   - name: Define env-like vars

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -19,23 +19,6 @@ runs:
       /usr/local/.ghcup/bin/cabal --version
       /usr/local/.ghcup/bin/cabal path
 
-      # Does it already have store path?
-      echo >> !!!!!!!!!!!!!
-      cat ~/.config/cabal/config
-      echo >> !!!!!!!!!!!!!
-
-      # Cabal used to be using non-xdg path
-      # https://github.com/haskell/cabal/blob/master/release-notes/cabal-install-3.10.1.0.md#significant-changes
-      echo "Default XDG paths:"
-      echo "XDG_STATE_HOME: $XDG_STATE_HOME"
-      echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
-      echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
-
-      echo "Setting some XDG paths for cabal.."
-      echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_ENV"
-      echo "XDG_STATE_HOME=$HOME/.local/state" >> "$GITHUB_ENV"
-      echo "XDG_CACHE_HOME=$HOME/.cache" >> "$GITHUB_ENV"
-
   # Because we cannot have `env` vars in composite action:
   - name: Define env-like vars
     id: vars
@@ -46,7 +29,6 @@ runs:
       echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
       echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
 
-      /usr/local/.ghcup/bin/cabal path
       ver="$(/usr/local/.ghcup/bin/cabal --version | head -n 1 | awk '{print $3}')"
       echo "cabal-version=$ver" >> "$GITHUB_OUTPUT"
       echo "cabal-version=$ver"
@@ -72,6 +54,7 @@ runs:
     run: |
       # setup PATH manually (since `haskell-actions/setup` is not run on cache hit)
       echo "$HOME/.ghcup/ghc/${{ inputs.ghc-version }}/bin" >> "$GITHUB_PATH"
+      # TODO: Is this correct for doctest installation path?
       echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
       # inspect preinstalled versions of GHC and Cabal
       ghc --version
@@ -98,12 +81,10 @@ runs:
     run: |
       mv /usr/local/.ghcup/bin/cabal{-old,}
 
-      cabal path # the store path must be ~/.local/state/cabal/store
-      echo >> !!!!!!!!!!!!!
-      cat ~/.config/cabal/config
-      echo >> !!!!!!!!!!!!!
-      rm ~/.config/cabal/config
-      cabal path # the store path must be ~/.local/state/cabal/store
+      # haskell-actions/setup@v2 intentinally sets non-XDG mode, however, let's disable that behavior
+      ls -lA ~/.cabal
+      rm -rf ~/.cabal
+      rm ~/.config/cabal/config # the last line (`store-dir: /home/runner/.cabal/store`) is created by the setup action
 
   - name: Inspect
     shell: bash

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -15,19 +15,16 @@ runs:
     shell: bash
     run: |
       /usr/local/.ghcup/bin/cabal --version
+
+      # This crates `~/.config/cabal/config`. It's super important for having persistent cabal stoer path.
       /usr/local/.ghcup/bin/cabal path
 
-      # Cabal path change:
+      # Cabal used to be using non-xdg path
       # https://github.com/haskell/cabal/blob/master/release-notes/cabal-install-3.10.1.0.md#significant-changes
       echo "Default XDG paths:"
       echo "XDG_STATE_HOME: $XDG_STATE_HOME"
       echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
       echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
-
-      echo "Setting some XDG paths for cabal.."
-      echo "XDG_CONFIG_HOME=$HOME/.config" >> "$GITHUB_OUTPUT"
-      echo "XDG_STATE_HOME=$HOME/.local/state" >> "$GITHUB_OUTPUT"
-      echo "XDG_CACHE_HOME=$HOME/.cache" >> "$GITHUB_OUTPUT"
 
   # Because we cannot have `env` vars in composite action:
   - name: Define env-like vars
@@ -83,7 +80,12 @@ runs:
   - name: Post downloading GHC ${{ inputs.ghc-version }}
     if: steps.ghc-cache.outputs.cache-hit != 'true'
     shell: bash
-    run: mv /usr/local/.ghcup/bin/cabal{-old,}
+    run: |
+      mv /usr/local/.ghcup/bin/cabal{-old,}
+
+      # come back to the initial state, otherwise the path is wrong
+      rm ~/.cabal/config || true
+      rm ~/.config/cabal/config || true
 
   - name: Inspect
     shell: bash

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -15,6 +15,7 @@ runs:
     shell: bash
     run: |
       ls -lA ~/ | grep .ghcup # we have ~/.ghcup -> /usr/local/.ghcup
+      echo "$PATH" # default `PATH` contains `~/.local/bin`, where (recent) `cabal` installs executables
 
       /usr/local/.ghcup/bin/cabal --version
       /usr/local/.ghcup/bin/cabal path
@@ -24,20 +25,15 @@ runs:
     id: vars
     shell: bash
     run: |
-      echo "Current XDG paths:"
-      echo "XDG_STATE_HOME: $XDG_STATE_HOME"
-      echo "XDG_CONFIG_HOME: $XDG_CONFIG_HOME"
-      echo "XDG_CACHE_HOME: $XDG_CACHE_HOME"
-
       ver="$(/usr/local/.ghcup/bin/cabal --version | head -n 1 | awk '{print $3}')"
       echo "cabal-version=$ver" >> "$GITHUB_OUTPUT"
       echo "cabal-version=$ver"
-      # The dummy version MUST NOT be equal to the preinstalled version, otherwise Cabal is overridden (?) and
-      # we cannot share the cache:
+      # The dummy version MUST NOT be equal to the preinstalled version, otherwise Cabal is
+      # overridden and we cannot share the cache:
       echo "dummy-cabal-version=3.12" >> "$GITHUB_OUTPUT"
       echo "dummy-cabal-version=3.12"
 
-  # FIXME: The cache is too large. Select necessary files in `lib/`.
+  # FIXME: The cache is too large. Select only necessary files in `lib/`.
   - name: Restore GHC ${{ inputs.ghc-version }}
     uses: actions/cache/restore@v4
     id: ghc-cache
@@ -54,12 +50,10 @@ runs:
     run: |
       # setup PATH manually (since `haskell-actions/setup` is not run on cache hit)
       echo "$HOME/.ghcup/ghc/${{ inputs.ghc-version }}/bin" >> "$GITHUB_PATH"
-      # TODO: Is this correct for doctest installation path?
-      echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"
       # inspect preinstalled versions of GHC and Cabal
       ghc --version
       cabal --version
-      cabal path # the store path must be ~/.local/state/cabal/store
+      cabal path # the store path must be `~/.local/state/cabal/store`
 
   # I don't want to install Cabal with haskell-actions@setup, so:
   - name: Pre downloading GHC ${{ inputs.ghc-version }}
@@ -67,6 +61,7 @@ runs:
     shell: bash
     run: mv /usr/local/.ghcup/bin/cabal{,-old}
 
+  # TODO: we should rather call the `~/.ghcup` by ourselves
   - name: Download GHC ${{ inputs.ghc-version }}
     uses: haskell-actions/setup@v2
     if: steps.ghc-cache.outputs.cache-hit != 'true'
@@ -81,7 +76,8 @@ runs:
     run: |
       mv /usr/local/.ghcup/bin/cabal{-old,}
 
-      # haskell-actions/setup@v2 intentinally sets non-XDG mode, however, let's disable that behavior
+      # `haskell-actions/setup@v2` intentinally sets non-XDG mode, however, we'll disable that
+      # behavior in order to match the initial environment:
       ls -lA ~/.cabal
       rm -rf ~/.cabal
       rm ~/.config/cabal/config # the last line (`store-dir: /home/runner/.cabal/store`) is created by the setup action

--- a/.github/actions/setup-ghc/action.yml
+++ b/.github/actions/setup-ghc/action.yml
@@ -58,8 +58,6 @@ runs:
     if: steps.ghc-cache.outputs.cache-hit == 'true'
     shell: bash
     run: |
-      # remove the configuration file in order to match to the initial state, namely the store path:
-      /home/runner/.config/cabal/config
       # setup PATH manually (since `haskell-actions/setup` is not run on cache hit)
       echo "$HOME/.ghcup/ghc/${{ inputs.ghc-version }}/bin" >> "$GITHUB_PATH"
       echo "$HOME/.cabal/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -121,8 +121,7 @@ jobs:
         run: |
           cabal path
           cabal install doctest
-          # Is it ~/.local/bin?
-          which doctest
+          which doctest # `~/.local/bin` (in PATH by default)
           cabal repl --with-ghc=doctest --repl-options='-w -Wdefault'
 
   verify:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -119,7 +119,10 @@ jobs:
 
       - name: Run doctest
         run: |
+          cabal path
           cabal install doctest
+          # Is it ~/.local/bin?
+          which doctest
           cabal repl --with-ghc=doctest --repl-options='-w -Wdefault'
 
   verify:

--- a/flake.nix
+++ b/flake.nix
@@ -62,17 +62,6 @@
 
               # GHC 9.8.4
               (haskell.compiler.ghc984.override { useLLVM = true; })
-              (haskell.compiler.ghc984.withPackages (
-                hpkgs: with hpkgs; [
-                  bitvec
-                  bytestring
-                  primitive
-                  random
-                  vector
-                  vector-algorithms
-                  wide-word
-                ]
-              ))
               # FIXME:
               (haskell-language-server.override { supportedGhcVersions = [ "984" ]; })
               haskell.packages.ghc984.cabal-fmt


### PR DESCRIPTION
Which is correct: `~/.cabal/store` or `~/.local/state/cabal/store`. I wonder whether the `haskell-actions/setup@v2` changes the store path.